### PR TITLE
Fixed completion for discover-my-mode

### DIFF
--- a/discover-my-major.el
+++ b/discover-my-major.el
@@ -201,7 +201,7 @@ If ARG is non-nil recreate the makey popup function even if it is already define
   (let ((active-modes))
     (mapc (lambda (mode) (condition-case nil
                         (if (and (symbolp mode) (symbol-value mode))
-                            (add-to-list 'active-modes (format "%s" mode)))
+                            (add-to-list 'active-modes (prin1-to-string mode)))
                       (error nil) ))
           minor-mode-list)
     active-modes))

--- a/discover-my-major.el
+++ b/discover-my-major.el
@@ -175,7 +175,7 @@ If ARG is non-nil recreate the makey popup function even if it is already define
   (interactive
    (let* ((active-modes (dmm/list-active-modes)))
      (list
-      (completing-read "Discover mode: " active-modes 'symbolp t nil 'dmm/discover-my-mode-history nil))))
+      (completing-read "Discover mode: " active-modes (lambda (_) t) t nil 'dmm/discover-my-mode-history nil))))
   (let* ((mode-name (if (symbolp mode)
                         (symbol-name mode)
                       mode))
@@ -201,7 +201,7 @@ If ARG is non-nil recreate the makey popup function even if it is already define
   (let ((active-modes))
     (mapc (lambda (mode) (condition-case nil
                         (if (and (symbolp mode) (symbol-value mode))
-                            (add-to-list 'active-modes mode))
+                            (add-to-list 'active-modes (format "%s" mode)))
                       (error nil) ))
           minor-mode-list)
     active-modes))


### PR DESCRIPTION
When using discover-my-mode with helm enabled the completion list was always empty.
I tried it without helm enabled and completion still was not working, and was getting the following error:
completion--some: Invalid function: (transient-mark-mode line-number-mode ...

I changed the active-modes list used as the completion source to be a list of strings to make it work.
Tested with and without helm.